### PR TITLE
Multiple date picker fixes

### DIFF
--- a/index.html
+++ b/index.html
@@ -227,6 +227,7 @@
             <div id="controls-container">
                 <button id="folderPicker" class="control-btn">Choose Folder</button>
                 <button id="layerBtn" class="control-btn">Layers</button>
+                <button id="goBtn" class="control-btn">GO</button>
             </div>
             <div id="layerOptions" style="display: none;">
                 <h4>View Options</h4>
@@ -964,18 +965,17 @@
                 loadTimelineDataInDateRange(startDate, endDate);
             });
 
-            const handleDateChange = () => {
+            document.getElementById('goBtn').addEventListener('click', () => {
                 const startDate = new Date(startDatePicker.value);
                 const endDate = new Date(endDatePicker.value);
                 if (startDate > endDate) {
                     alert('Start date must be before end date.');
                     return;
                 }
+				startDatePicker.value = moment.utc(startDate).format('YYYY-MM-DD');
+                endDatePicker.value = moment.utc(endDate).format('YYYY-MM-DD');
                 loadTimelineDataInDateRange(startDate, endDate);
-            };
-
-            startDatePicker.addEventListener('change', handleDateChange);
-            endDatePicker.addEventListener('change', handleDateChange);
+            });
         }
 
         function populateActivityFilters() {

--- a/index.html
+++ b/index.html
@@ -337,6 +337,7 @@
 		}
 
 		async function loadTimelineDataForDate(selectedDate) {
+			selectedDate.setMinutes(selectedDate.getMinutes() + selectedDate.getTimezoneOffset());
 			const year = selectedDate.getFullYear();
 			const month = selectedDate.toLocaleString('default', {
 				month: 'long'
@@ -946,20 +947,20 @@
             document.getElementById('prevDayBtn').addEventListener('click', () => {
                 const startDate = new Date(startDatePicker.value);
                 const endDate = new Date(endDatePicker.value);
-                startDate.setDate(startDate.getDate() - 1);
-                endDate.setDate(endDate.getDate() - 1);
-                startDatePicker.value = moment(startDate).format('YYYY-MM-DD');
-                endDatePicker.value = moment(endDate).format('YYYY-MM-DD');
+                startDate.setUTCDate(startDate.getUTCDate() - 1);
+                endDate.setUTCDate(endDate.getUTCDate() - 1);
+                startDatePicker.value = moment.utc(startDate).format('YYYY-MM-DD');
+                endDatePicker.value = moment.utc(endDate).format('YYYY-MM-DD');
                 loadTimelineDataInDateRange(startDate, endDate);
             });
 
             document.getElementById('nextDayBtn').addEventListener('click', () => {
                 const startDate = new Date(startDatePicker.value);
                 const endDate = new Date(endDatePicker.value);
-                startDate.setDate(startDate.getDate() + 1);
-                endDate.setDate(endDate.getDate() + 1);
-                startDatePicker.value = moment(startDate).format('YYYY-MM-DD');
-                endDatePicker.value = moment(endDate).format('YYYY-MM-DD');
+                startDate.setUTCDate(startDate.getUTCDate() + 1);
+                endDate.setUTCDate(endDate.getUTCDate() + 1);
+                startDatePicker.value = moment.utc(startDate).format('YYYY-MM-DD');
+                endDatePicker.value = moment.utc(endDate).format('YYYY-MM-DD');
                 loadTimelineDataInDateRange(startDate, endDate);
             });
 


### PR DESCRIPTION
The update to the date picker for multiple days broke the previous/next buttons in negative time zones again.  

I discovered an old issue with the previous button causing a one month backward jump from the current day if it was the first day of the month.
Also, there was an issue with the timeline data being one day behind the date picker in negative time zones.

The datePicker change events were too sensitive.  If you tried to type a date manually, it would launch on every keypress.
Please reformat or relocate the GO button as you wish.

