### PR TITLE
Add iOS Example timeline

### DIFF
--- a/sample_data/Local_format/iOS/Timeline.json
+++ b/sample_data/Local_format/iOS/Timeline.json
@@ -1,0 +1,100 @@
+{
+  "timelineObjects": [
+    {
+      "placeVisit": {
+        "location": {
+          "latitudeE7": 407588951,
+          "longitudeE7": -739851310,
+          "placeId": "ChIJmQJIxlVYwokRLgeuocVOGVU",
+          "address": "Times Square, Manhattan, NY 10036, USA",
+          "name": "Times Square",
+          "locationConfidence": 95.0,
+          "calibratedProbability": 90.0
+        },
+        "duration": {
+          "startTimestamp": "2024-01-10T09:00:00Z",
+          "endTimestamp": "2024-01-10T10:30:00Z"
+        },
+        "placeConfidence": "HIGH_CONFIDENCE",
+        "centerLatE7": 407588951,
+        "centerLngE7": -739851310,
+        "visitConfidence": 90,
+        "editConfirmationStatus": "NOT_CONFIRMED",
+        "placeVisitType": "SINGLE_PLACE",
+        "placeVisitImportance": "MAIN"
+      }
+    },
+    {
+      "activitySegment": {
+        "startLocation": {
+          "latitudeE7": 407588951,
+          "longitudeE7": -739851310
+        },
+        "endLocation": {
+          "latitudeE7": 407505801,
+          "longitudeE7": -739935863
+        },
+        "duration": {
+          "startTimestamp": "2024-01-10T10:30:00Z",
+          "endTimestamp": "2024-01-10T10:55:00Z"
+        },
+        "distance": 1200,
+        "activityType": "WALKING",
+        "confidence": "HIGH",
+        "activities": [
+          {
+            "activityType": "WALKING",
+            "probability": 98.5
+          },
+          {
+            "activityType": "STILL",
+            "probability": 1.0
+          }
+        ],
+        "waypointPath": {
+          "waypoints": [
+            {
+              "latE7": 407588951,
+              "lngE7": -739851310
+            },
+            {
+              "latE7": 407547381,
+              "lngE7": -739893240
+            },
+            {
+              "latE7": 407505801,
+              "lngE7": -739935863
+            }
+          ],
+          "distanceMeters": 1250.5,
+          "travelMode": "WALK",
+          "confidence": 1.0
+        }
+      }
+    },
+    {
+      "placeVisit": {
+        "location": {
+          "latitudeE7": 407505801,
+          "longitudeE7": -739935863,
+          "placeId": "ChIJhRwB-yFawokR5Phil-QQ3zM",
+          "address": "Madison Square Garden, 4 Pennsylvania Plaza, New York, NY 10001, USA",
+          "name": "Madison Square Garden",
+          "locationConfidence": 98.0,
+          "calibratedProbability": 95.0
+        },
+        "duration": {
+          "startTimestamp": "2024-01-10T10:55:00Z",
+          "endTimestamp": "2024-01-10T13:00:00Z"
+        },
+        "placeConfidence": "HIGH_CONFIDENCE",
+        "centerLatE7": 407505801,
+        "centerLngE7": -739935863,
+        "visitConfidence": 95,
+        "editConfirmationStatus": "NOT_CONFIRMED",
+        "placeVisitType": "SINGLE_PLACE",
+        "placeVisitImportance": "MAIN"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
NYC Walk from Times Square to Madison Square Garden.

Contains direction but is not handling waypoints

<img width="1495" alt="image" src="https://github.com/user-attachments/assets/e050a689-fbf0-4996-9deb-43bdb24da3e7" />
